### PR TITLE
Prevent action button from wrapping, and give it margin from user's name and title when these are long

### DIFF
--- a/resources/js/components/Card.vue
+++ b/resources/js/components/Card.vue
@@ -32,9 +32,9 @@
                         </div>
                         <div
                             v-if="card.button"
-                            class="mt-5 flex justify-center sm:mt-0">
+                            class="mt-5 flex justify-center sm:mt-0 ml-1">
                             <Link :href="card.button_target"
-                                  :class="card.button_style ?? 'flex justify-center items-center px-4 py-2 border border-gray-300 dark:border-gray-800 shadow-sm dark:shadow-inner text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white hover:bg-gray-50 dark:bg-gray-700 hover:dark:bg-gray-600'">
+                                  :class="card.button_style ?? 'flex justify-center items-center px-4 py-2 border border-gray-300 dark:border-gray-800 shadow-sm dark:shadow-inner text-sm font-medium whitespace-nowrap rounded-md text-gray-700 dark:text-gray-300 bg-white hover:bg-gray-50 dark:bg-gray-700 hover:dark:bg-gray-600'">
                                 {{ card.button_name }}
                             </Link>
                         </div>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dbeff92f-8689-4ad8-a394-f9e2539e8a21)

After:
![image](https://github.com/user-attachments/assets/e5f93d0c-860c-43a1-85a0-5c53a5d79ed1)

Thank you for this nice card Mücahit!😊